### PR TITLE
Clean impressions

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -69,7 +69,7 @@ Ratemypup::Application.configure do
   
   require "#{Rails.root}/lib/smtp_tls"
 
-  config.action_mailer.default_url_options = { :host => 'www.simpatico-pup.herokuapp.com' }
+  config.action_mailer.default_url_options = { :host => 'simpatico-pup.herokuapp.com' }
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.perform_deliveries = true 
   ActionMailer::Base.delivery_method = :smtp

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -1,0 +1,7 @@
+namespace :scheduler do
+  desc "Drops old impressions records (8 days)"
+  task clean_impressions: :environment do
+    Impressions.where("updated_at < ?", Time.now - 8*24*60*60).destroy_all
+  end
+
+end


### PR DESCRIPTION
This pull req contains scheduler.rake, which contains a task clean_impressions which will be scheduled to run every day and will destroy any records in the impressions table that are older than 8 days.