### PR TITLE
override to_s method on user object

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,6 +26,11 @@ class User < ActiveRecord::Base
     BCrypt::Password.create(string, cost: cost)
   end
 
+  # Override to_s method for community forum
+  def to_s
+    username
+  end
+
 
   # Iter 2-2 account actication (by Zipei Wang and Jack Chen)
   # Returns true if the given token matches the digest.
@@ -94,4 +99,3 @@ class User < ActiveRecord::Base
 
 
 end
-


### PR DESCRIPTION
- Thredded gem calls to_s on User class for the username which defaults to the string representation of the object
- Added override to to_s method on User class to return the username